### PR TITLE
fix: fix the release.config.js plugins

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -5,8 +5,8 @@ module.exports = {
         "@semantic-release/commit-analyzer",
         "@semantic-release/release-notes-generator",
         // "@semantic-release/npm",
-        "@semantic-release/git"
+        "@semantic-release/github"
       ]
-
+  
 }
 //  // "@semantic-release/npm", this is for npm packages 


### PR DESCRIPTION
in the new version it uses github instead of git 